### PR TITLE
Removed auto checking for monitor resolution on first launch and set …

### DIFF
--- a/src/Gunz/ZConfiguration.cpp
+++ b/src/Gunz/ZConfiguration.cpp
@@ -729,14 +729,14 @@ bool ZConfiguration::SaveToFile(const char *szFileName, const char* szHeader)
 void ZConfiguration::Init()
 {
 	m_Video.FullscreenMode = FullscreenType::Fullscreen;
-	auto Width = GetSystemMetrics(SM_CXSCREEN);
+	/* auto Width = GetSystemMetrics(SM_CXSCREEN);
 	if (Width == 0)
 		Width = 1024;
 	auto Height = GetSystemMetrics(SM_CYSCREEN);
 	if (Height == 0)
-		Height = 768;
-	m_Video.nWidth = Width;
-	m_Video.nHeight = Height;
+		Height = 768; */
+	m_Video.nWidth = 1024;
+	m_Video.nHeight = 768;
 	m_Video.nColorBits = 32;
 	m_Video.nGamma = 255;
 	m_Video.bReflection = true;


### PR DESCRIPTION
…it to 1024x768 default because game client fails to launch if a resolution which is not found in the drop down config menu is utilized and requires manually updating the config.xml