### PR TITLE
fix bounty not updating after item purchase

### DIFF
--- a/src/CSCommon/Source/MSharedCommandTable.cpp
+++ b/src/CSCommon/Source/MSharedCommandTable.cpp
@@ -623,6 +623,7 @@ void MAddSharedCommandTable(MCommandManager* CommandManager, MSharedCommandType:
 			P(MPT_UINT, "ItemID");
 		C(MC_MATCH_RESPONSE_BUY_ITEM, "Match.ResponseBuyItem", "Response Buy Item", MCDT_MACHINE2MACHINE);
 			P(MPT_INT, "result");
+			P(MPT_INT, "Bounty"); // current player bounty only when result is MOK, otherwise always 0
 		C(MC_MATCH_REQUEST_SELL_ITEM, "Match.RequestSellItem", "Request Sell Item", MCDT_MACHINE2MACHINE);
 			P(MPT_UID, "uidChar");
 			P(MPT_UID, "uidItem");

--- a/src/Gunz/ZGameInterface_OnCommand.cpp
+++ b/src/Gunz/ZGameInterface_OnCommand.cpp
@@ -350,10 +350,13 @@ bool ZGameInterface::OnCommand(MCommand* pCommand)
 	case MC_MATCH_RESPONSE_BUY_ITEM:
 		{
 			int nResult;
+			int nBP;
 			pCommand->GetParameter(&nResult, 0, MPT_INT);
+			pCommand->GetParameter(&nBP, 1, MPT_INT);
+			
 			if (nResult == MOK)
 			{
-				ZApplication::GetGameInterface()->ShowMessage(MSG_GAME_BUYITEM);
+				ZApplication::GetGameInterface()->OnResponseBuyQuestItem(nResult, nBP);
 			}
 			else if ((nResult == MERR_TOO_EXPENSIVE_BOUNTY) || (nResult == MERR_TOO_MANY_ITEM))
 			{

--- a/src/MatchServer/MMatchServer_Item.cpp
+++ b/src/MatchServer/MMatchServer_Item.cpp
@@ -62,6 +62,7 @@ bool MMatchServer::BuyItem(MMatchObject* pObject, unsigned int nItemID, bool bRe
 	{
 		MCommand* pNew = CreateCommand(MC_MATCH_RESPONSE_BUY_ITEM, MUID(0,0));
 		pNew->AddParameter(new MCmdParamInt(MERR_TOO_MANY_ITEM));
+		pNew->AddParameter(new MCmdParamInt(0));
 		RouteToListener(pObject, pNew);
 
 		return false;
@@ -73,6 +74,7 @@ bool MMatchServer::BuyItem(MMatchObject* pObject, unsigned int nItemID, bool bRe
 	{
 		MCommand* pNew = CreateCommand(MC_MATCH_RESPONSE_BUY_ITEM, MUID(0,0));
 		pNew->AddParameter(new MCmdParamInt(MERR_TOO_EXPENSIVE_BOUNTY));
+		pNew->AddParameter(new MCmdParamInt(0));
 		RouteToListener(pObject, pNew);
 
 		return false;
@@ -87,6 +89,7 @@ bool MMatchServer::BuyItem(MMatchObject* pObject, unsigned int nItemID, bool bRe
 	{
 		MCommand* pNew = CreateCommand(MC_MATCH_RESPONSE_BUY_ITEM, MUID(0,0));
 		pNew->AddParameter(new MCmdParamInt(MERR_CANNOT_BUY_ITEM));
+		pNew->AddParameter(new MCmdParamInt(0));
 		RouteToListener(pObject, pNew);
 
 		return false;
@@ -94,7 +97,7 @@ bool MMatchServer::BuyItem(MMatchObject* pObject, unsigned int nItemID, bool bRe
 
 
 	// 오브젝트에 바운티 깎는다.
-	pObject->GetCharInfo()->m_nBP -= nPrice;
+	pObject->GetCharInfo()->DecBP(nPrice);
 
 	// 오브젝트에 아이템 추가
 	MUID uidNew = MMatchItemMap::UseUID();
@@ -103,6 +106,7 @@ bool MMatchServer::BuyItem(MMatchObject* pObject, unsigned int nItemID, bool bRe
 
 	MCommand* pNew = CreateCommand(MC_MATCH_RESPONSE_BUY_ITEM, MUID(0,0));
 	pNew->AddParameter(new MCmdParamInt(MOK));
+	pNew->AddParameter(new MCmdParamInt(pObject->GetCharInfo()->m_nBP));
 	RouteToListener(pObject, pNew);
 
 	return true;


### PR DESCRIPTION
This fixes #1.

Return the player current BP as a parameter on the MC_MATCH_RESPONSE_BUY_ITEM command.
It will only hold the correct value when the response of the command is MOK, otherwise 0.